### PR TITLE
Add image cmodel support

### DIFF
--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -102,9 +102,11 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   $ids = array();
   $ids['pid'] = $pid;
   $ids['cmodel'] = islandora_object_load($pid)->models[0];
-  $cmodel_dsids = array('ir:citationCModel' => 'PDF', 
-                        'ir:thesisCModel' => 'PDF', 
-                        'islandora:sp_pdf' => 'OBJ');
+  $cmodel_dsids = array('ir:citationCModel' => 'PDF',
+                        'ir:thesisCModel' => 'PDF',
+                        'islandora:sp_pdf' => 'OBJ',
+                        'islandora:sp_basic_image' => 'OBJ',
+                        'islandora:sp_large_image_cmodel' => 'OBJ');
   if ($ids['cmodel'] == '') {
     echo json_encode(array('error' => "PID '${ids['pid']}' does not exist")); 
     drupal_exit();


### PR DESCRIPTION
Tested basic image and large images, haven't found any problems. Should theoretically be able to support all content models.

This pull request adds support for the Basic Image and Large Image CModels. Testing seems to indicate that all others could also be added.
